### PR TITLE
Update express-openid-connect to ^0.5.

### DIFF
--- a/lab-01/end/package-lock.json
+++ b/lab-01/end/package-lock.json
@@ -26,26 +26,18 @@
       "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/topo": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
-      "integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "^8.3.0"
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
-          "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
         }
-      }
-    },
-    "@panva/jose": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@panva/jose/-/jose-1.9.2.tgz",
-      "integrity": "sha512-Uw/ggY8nlemS23Sec1ud6A09I0x6Hji7Ma2xe+EMP2FbkWRt1IAhoK0lBMmMsrsOLVXV/6udcq11MDaeef9jRA==",
-      "requires": {
-        "asn1.js": "^5.1.1"
       }
     },
     "@sindresorhus/is": {
@@ -71,12 +63,12 @@
       }
     },
     "aggregate-error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-      "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "requires": {
         "clean-stack": "^2.0.0",
-        "indent-string": "^3.2.0"
+        "indent-string": "^4.0.0"
       }
     },
     "array-flatten": {
@@ -269,9 +261,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
+      "integrity": "sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -379,15 +371,15 @@
       }
     },
     "express-openid-connect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-0.4.0.tgz",
-      "integrity": "sha512-eeIU9ajgaEJZstJmRfmmcnyPVH7raMrSS2D/8cKCNruvtbtBll6m4lrSarSjG2YkfxgvwyVSuyig8+fmXi6BSw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-0.5.0.tgz",
+      "integrity": "sha512-7xoP8U6giFdExg5ZuCARbhRAkJeTSddn119UheQLZrgxQ2bIZn9wW8NFlwMzOXxKjZflZnxU7UuZFVIr3X35Yg==",
       "requires": {
         "@hapi/joi": "^14.5.0",
         "cb": "^0.1.0",
         "clone": "^2.1.2",
         "http-errors": "^1.7.3",
-        "openid-client": "^3.7.2",
+        "openid-client": "^3.7.3",
         "p-memoize": "^3.1.0",
         "url-join": "^4.0.1"
       },
@@ -497,9 +489,9 @@
       }
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inherits": {
       "version": "2.0.3",
@@ -517,6 +509,14 @@
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
+      }
+    },
+    "jose": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.12.0.tgz",
+      "integrity": "sha512-pVfsVLMNerEIaPfCvc901iDxhp6loCUEud2nwfiJZrpcOOuYVYny22Wto/7SDnvT+7v5COV5lHgO9UQRY94X5w==",
+      "requires": {
+        "asn1.js": "^5.2.0"
       }
     },
     "json-buffer": {
@@ -659,19 +659,19 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "normalize-url": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.4.1.tgz",
-      "integrity": "sha512-rjH3yRt0Ssx19mUwS0hrDUOdG9VI+oRLpLHJ7tXRdjcuQ7v7wo6qPvOZppHRrqfslTKr0L2yBhjj4UXd7c3cQg=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
+      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
     },
     "oidc-token-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-3.0.2.tgz",
-      "integrity": "sha512-dTzp80/y/da+um+i+sOucNqiPpwRL7M/xPwj7pH1TFA2/bqQ+OK2sJahSXbemEoLtPkHcFLyhLhLWZa9yW5+RA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-4.0.0.tgz",
+      "integrity": "sha512-CqbuRvuV+tfiAvU7fQsOkmQ3ROTSFChZy/3z2OMs5xetxz1q/j1B4/FDaK1M9xNsPGfdJxdiLbPbOXZDtHI2NA=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -695,18 +695,18 @@
       }
     },
     "openid-client": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.7.2.tgz",
-      "integrity": "sha512-1zt7SVpGC1oL8bcWgpCSdTLB04GWRotZvxvELxVIAAR8VhSlw+IxUVFXEJupmG7glnweMtRV4DMCs7y3vqEF+w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.8.2.tgz",
+      "integrity": "sha512-hJpK40+RKuc83Ldln/JUjBAdNNA0L5AamlQtCr093uziDgpwFE78x3ELK6wuQ2e0HeCk6hlCbgbq8oE6cgdUNQ==",
       "requires": {
-        "@panva/jose": "^1.9.0",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
-        "lodash": "^4.17.13",
+        "jose": "^1.10.2",
+        "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "make-error": "^1.3.5",
-        "object-hash": "^1.3.1",
-        "oidc-token-hash": "^3.0.2",
+        "object-hash": "^2.0.0",
+        "oidc-token-hash": "^4.0.0",
         "p-any": "^2.1.0"
       }
     },
@@ -960,9 +960,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.0.tgz",
-      "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     }
   }
 }

--- a/lab-01/end/package.json
+++ b/lab-01/end/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^6.1.0",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
-    "express-openid-connect": "^0.4.0",
+    "express-openid-connect": "^0.5.0",
     "morgan": "^1.9.1"
   }
 }

--- a/lab-02/begin/webapp/package.json
+++ b/lab-02/begin/webapp/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^6.2.0",
     "ejs": "^2.7.1",
     "express": "^4.17.1",
-    "express-openid-connect": "^0.4.0",
+    "express-openid-connect": "^0.5.0",
     "morgan": "^1.9.1",
     "request": "^2.88.0",
     "request-promise": "^4.2.4"

--- a/lab-02/end/webapp/package-lock.json
+++ b/lab-02/end/webapp/package-lock.json
@@ -26,26 +26,18 @@
       "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
     },
     "@hapi/topo": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
-      "integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "^8.3.0"
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
-          "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
         }
-      }
-    },
-    "@panva/jose": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@panva/jose/-/jose-1.9.2.tgz",
-      "integrity": "sha512-Uw/ggY8nlemS23Sec1ud6A09I0x6Hji7Ma2xe+EMP2FbkWRt1IAhoK0lBMmMsrsOLVXV/6udcq11MDaeef9jRA==",
-      "requires": {
-        "asn1.js": "^5.1.1"
       }
     },
     "@sindresorhus/is": {
@@ -71,12 +63,12 @@
       }
     },
     "aggregate-error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
-      "integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
       "requires": {
         "clean-stack": "^2.0.0",
-        "indent-string": "^3.2.0"
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -323,9 +315,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
+      "integrity": "sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -432,15 +424,15 @@
       }
     },
     "express-openid-connect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-0.4.0.tgz",
-      "integrity": "sha512-eeIU9ajgaEJZstJmRfmmcnyPVH7raMrSS2D/8cKCNruvtbtBll6m4lrSarSjG2YkfxgvwyVSuyig8+fmXi6BSw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-0.5.0.tgz",
+      "integrity": "sha512-7xoP8U6giFdExg5ZuCARbhRAkJeTSddn119UheQLZrgxQ2bIZn9wW8NFlwMzOXxKjZflZnxU7UuZFVIr3X35Yg==",
       "requires": {
         "@hapi/joi": "^14.5.0",
         "cb": "^0.1.0",
         "clone": "^2.1.2",
         "http-errors": "^1.7.3",
-        "openid-client": "^3.7.2",
+        "openid-client": "^3.7.3",
         "p-memoize": "^3.1.0",
         "url-join": "^4.0.1"
       },
@@ -607,9 +599,9 @@
       }
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inherits": {
       "version": "2.0.3",
@@ -638,6 +630,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jose": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-1.12.0.tgz",
+      "integrity": "sha512-pVfsVLMNerEIaPfCvc901iDxhp6loCUEud2nwfiJZrpcOOuYVYny22Wto/7SDnvT+7v5COV5lHgO9UQRY94X5w==",
+      "requires": {
+        "asn1.js": "^5.2.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -800,9 +800,9 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "normalize-url": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.4.1.tgz",
-      "integrity": "sha512-rjH3yRt0Ssx19mUwS0hrDUOdG9VI+oRLpLHJ7tXRdjcuQ7v7wo6qPvOZppHRrqfslTKr0L2yBhjj4UXd7c3cQg=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -810,14 +810,14 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-hash": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
-      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.0.tgz",
+      "integrity": "sha512-I7zGBH0rDKwVGeGZpZoFaDhIwvJa3l1CZE+8VchylXbInNiCj7sxxea9P5dTM4ftKR5//nrqxrdeGSTWL2VpBA=="
     },
     "oidc-token-hash": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-3.0.2.tgz",
-      "integrity": "sha512-dTzp80/y/da+um+i+sOucNqiPpwRL7M/xPwj7pH1TFA2/bqQ+OK2sJahSXbemEoLtPkHcFLyhLhLWZa9yW5+RA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-4.0.0.tgz",
+      "integrity": "sha512-CqbuRvuV+tfiAvU7fQsOkmQ3ROTSFChZy/3z2OMs5xetxz1q/j1B4/FDaK1M9xNsPGfdJxdiLbPbOXZDtHI2NA=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -841,18 +841,18 @@
       }
     },
     "openid-client": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.7.2.tgz",
-      "integrity": "sha512-1zt7SVpGC1oL8bcWgpCSdTLB04GWRotZvxvELxVIAAR8VhSlw+IxUVFXEJupmG7glnweMtRV4DMCs7y3vqEF+w==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-3.8.2.tgz",
+      "integrity": "sha512-hJpK40+RKuc83Ldln/JUjBAdNNA0L5AamlQtCr093uziDgpwFE78x3ELK6wuQ2e0HeCk6hlCbgbq8oE6cgdUNQ==",
       "requires": {
-        "@panva/jose": "^1.9.0",
         "base64url": "^3.0.1",
         "got": "^9.6.0",
-        "lodash": "^4.17.13",
+        "jose": "^1.10.2",
+        "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "make-error": "^1.3.5",
-        "object-hash": "^1.3.1",
-        "oidc-token-hash": "^3.0.2",
+        "object-hash": "^2.0.0",
+        "oidc-token-hash": "^4.0.0",
         "p-any": "^2.1.0"
       }
     },
@@ -1232,9 +1232,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.0.tgz",
-      "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     }
   }
 }

--- a/lab-02/end/webapp/package.json
+++ b/lab-02/end/webapp/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^6.1.0",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
-    "express-openid-connect": "^0.4.0",
+    "express-openid-connect": "^0.5.0",
     "morgan": "^1.9.1",
     "request": "^2.88.0",
     "request-promise": "^4.2.2"

--- a/lab-02/end/webapp/server.js
+++ b/lab-02/end/webapp/server.js
@@ -27,8 +27,9 @@ app.use(auth({
   authorizationParams: {
     response_type: 'code id_token',
     audience: process.env.API_AUDIENCE,
-    scope: 'openid profile email read:reports offline_access'
-  },
+    scope: 'openid profile email read:reports offline_access',
+    response_mode: 'form_post'
+  }
 }));
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
### Description
Upgraded dependency, `express-openid-connect` to latest version (0.5.0).  With this change we need to pass `response_mode='form_post'` else Auth0 returns a `fragment` response instead of the expected default `query` response. Without explicitly declaring `response_mode='form_post'",  we'll get  a `state missing from the response` error after upgrading the dependency.

Please note that the lab guide will also need to be updated to reflect this change if this PR is merged.

